### PR TITLE
Reduce VM costs

### DIFF
--- a/k8s-manifests/gitlab.yaml
+++ b/k8s-manifests/gitlab.yaml
@@ -102,12 +102,12 @@ spec:
           resources:
             requests:
               memory: 4Gi
-              cpu: "4"
-              ephemeral-storage: 3Gi
+              cpu: 1
+              ephemeral-storage: 500Mi
             limits:
               memory: 4Gi
-              cpu: "4"
-              ephemeral-storage: 3Gi
+              cpu: 1
+              ephemeral-storage: 500Mi
           livenessProbe:
             httpGet:
               path: /-/liveness

--- a/k8s-manifests/mongo.yaml
+++ b/k8s-manifests/mongo.yaml
@@ -32,6 +32,15 @@ spec:
       containers:
         - name: mongo
           image: mongo:4.2.2
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: "0.5"
+              ephemeral-storage: 100Mi
+            limits:
+              memory: 512Mi
+              cpu: "0.5"
+              ephemeral-storage: 100Mi
           command:
             - mongod
             - "--bind_ip_all"

--- a/k8s-manifests/postgres.yaml
+++ b/k8s-manifests/postgres.yaml
@@ -46,12 +46,14 @@ spec:
         - name: postgres
           image: postgres:14
           resources:
-           limits:
-             cpu: "1"
-             memory: "4Gi"
-           requests:
-             cpu: "1"
-             memory: "4Gi"
+            requests:
+              memory: 512Mi
+              cpu: "0.5"
+              ephemeral-storage: 100Mi
+            limits:
+              memory: 512Mi
+              cpu: "0.5"
+              ephemeral-storage: 100Mi
           env:
             - name: POSTGRES_PASSWORD
               value: password

--- a/k8s-manifests/redis.yaml
+++ b/k8s-manifests/redis.yaml
@@ -32,6 +32,15 @@ spec:
       containers:
         - name: redis
           image: redis:7.0-rc
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: "0.5"
+              ephemeral-storage: 100Mi
+            limits:
+              memory: 512Mi
+              cpu: "0.5"
+              ephemeral-storage: 100Mi
           livenessProbe:
             tcpSocket:
               port: 6379

--- a/k8s-manifests/rocket-chat.yaml
+++ b/k8s-manifests/rocket-chat.yaml
@@ -32,6 +32,15 @@ spec:
       containers:
         - name: rocket-chat
           image: rocket.chat:4.6.2
+          resources:
+            requests:
+              memory: 2Gi
+              cpu: 1
+              ephemeral-storage: 500Mi
+            limits:
+              memory: 2Gi
+              cpu: 1
+              ephemeral-storage: 500Mi
           livenessProbe:
             httpGet:
               path: /api/info


### PR DESCRIPTION
Autopilot settings allocated machines with too much CPU, memory and storage for this small use case. Defining smaller values or minimum defaults will hopefully reduce costs.